### PR TITLE
BaseWidgetTest wasn't rendering because of no height, fix with css

### DIFF
--- a/src/htmltests/BaseWidgetTest.html
+++ b/src/htmltests/BaseWidgetTest.html
@@ -147,6 +147,9 @@
         margin: 0;
         padding: 0;
       }
+      html, body, #wrap {
+        height: 100%;
+      }
       #glift_display1 {
         height:100%;
         position:relative;


### PR DESCRIPTION
I added CSS--- I also re-compiled, and there are script tag changes. Is that good?  I'm guessing it's because you changed the build system since the last time you checked it in? 

With this css the JS error was:
```
Uncaught Error: Div has has invalid dimensions. Bounding box had width: 1129, height: 0
http://localhost:9080/favicon.ico Failed to load resource: the server responded with a status of 404 (Not Found)
```
