### PR TITLE
fix AnimationTester not getting its deps regenerated

### DIFF
--- a/src/htmltests/AnimationTester.html
+++ b/src/htmltests/AnimationTester.html
@@ -3,6 +3,7 @@
 <head>
   <title> Animation Tester  </title>
 
+<!-- AUTO-GEN-DEPS -->
 <!-- . sources -->
 <script type="text/javascript" src=".././glift.js"></script>
 <script type="text/javascript" src=".././global.js"></script>


### PR DESCRIPTION
This file was missing the <!-- AUTO-GEN-DEPS --> magic and thus wasn't getting its deps regenerated automatically in depgen.py.
